### PR TITLE
Replace Blog page route and Add  loading view

### DIFF
--- a/src/components/common/Header.svelte
+++ b/src/components/common/Header.svelte
@@ -31,7 +31,7 @@ import {
 				<WandMagicSparklesOutline class='inline-block' />
 				Playground
 			</NavLi>
-			<NavLi href='/blog/1'>
+			<NavLi href='/blog/pages'>
 				<BookSolid class='inline-block' />
 				Blog
 			</NavLi>

--- a/src/routes/api/blog/page/+server.ts
+++ b/src/routes/api/blog/page/+server.ts
@@ -1,8 +1,10 @@
-import { json, error } from '@sveltejs/kit'
+import { error, json } from '@sveltejs/kit'
 import { getBlogPageDetail } from '$lib/microCMS'
 import type { RequestHandler } from './$types'
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: ({ url }: { url: any }) => Promise<Response> = async ({
+	url,
+}) => {
 	try {
 		const pageId = url.searchParams.get('pageId')
 		if (!pageId) {

--- a/src/routes/api/blog/page/+server.ts
+++ b/src/routes/api/blog/page/+server.ts
@@ -1,0 +1,17 @@
+import { json, error } from '@sveltejs/kit'
+import { getBlogPageDetail } from '$lib/microCMS'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url }) => {
+	try {
+		const pageId = url.searchParams.get('pageId')
+		if (!pageId) {
+			throw error(400, 'Missing pageId')
+		}
+		const data = await getBlogPageDetail(pageId)
+		return json(data)
+	} catch (e) {
+		console.error('Error fetching blog page detail:', e)
+		throw error(500, 'Failed to fetch blog page detail')
+	}
+}

--- a/src/routes/api/blog/pages/+server.ts
+++ b/src/routes/api/blog/pages/+server.ts
@@ -1,0 +1,18 @@
+import { json, error } from '@sveltejs/kit'
+import { getBlogPageList } from '$lib/microCMS'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url }) => {
+	try {
+		const pageParam = url.searchParams.get('page')
+		const page = pageParam ? Number(pageParam) : 1
+		const limit = 50
+		const offset = page > 1 ? (page - 1) * limit : 0
+
+		const data = await getBlogPageList({ limit, offset })
+		return json(data)
+	} catch (e) {
+		console.error('Error fetching blog pages:', e)
+		throw error(500, 'Failed to fetch blog pages')
+	}
+}

--- a/src/routes/api/blog/pages/+server.ts
+++ b/src/routes/api/blog/pages/+server.ts
@@ -1,8 +1,10 @@
-import { json, error } from '@sveltejs/kit'
+import { error, json } from '@sveltejs/kit'
 import { getBlogPageList } from '$lib/microCMS'
 import type { RequestHandler } from './$types'
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: ({ url }: { url: any }) => Promise<Response> = async ({
+	url,
+}) => {
 	try {
 		const pageParam = url.searchParams.get('page')
 		const page = pageParam ? Number(pageParam) : 1

--- a/src/routes/blog/[page]/+page.server.ts
+++ b/src/routes/blog/[page]/+page.server.ts
@@ -1,24 +1,10 @@
-import { error } from '@sveltejs/kit'
-import { getBlogPageList } from '$lib/microCMS'
+import { redirect } from '@sveltejs/kit'
 // @ts-ignore
 import type { PageServerLoad } from './$types'
 
-export const load: PageServerLoad = async ({
-	params,
-}: {
-	params: { page: string }
-}) => {
-	const queries: { offset: number; limit: number } = { offset: 0, limit: 50 }
-
-	if (params.page) {
-		queries.offset = (Number(params.page) - 1) * queries.limit
-	}
-	try {
-		return await getBlogPageList(queries)
-	} catch (e) {
-		console.error('Error fetching blog page list:', e)
-		error(500, 'An unexpected error occurred')
-	}
+export const load: PageServerLoad = async ({ params }: { params: { page: string } }) => {
+	const page = params.page ?? '1'
+	throw redirect(308, `/blog/pages?page=${encodeURIComponent(page)}`)
 }
 
 export const prerender = true

--- a/src/routes/blog/page/+page.server.ts
+++ b/src/routes/blog/page/+page.server.ts
@@ -1,0 +1,26 @@
+import { error } from '@sveltejs/kit'
+import { getBlogPageDetail } from '$lib/microCMS'
+// @ts-ignore
+import type { PageServerLoad } from './$types'
+
+export const load: ({ url }: { url: URL }) => Promise<Blog> = async ({
+	url,
+}: {
+	url: URL
+}) => {
+	const pageId = url.searchParams.get('pageId') ?? ''
+	if (pageId.length < 1) {
+		error(400, 'Missing required query parameter: pageId')
+	}
+	try {
+		return await getBlogPageDetail(pageId)
+	} catch (e: unknown) {
+		let status = 500
+		if ((e as Error).message === 'Not found') {
+			status = 404
+		}
+		error(status)
+	}
+}
+
+export const prerender = true

--- a/src/routes/blog/page/+page.svelte
+++ b/src/routes/blog/page/+page.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+import { load } from 'cheerio'
+import { Badge, Heading } from 'flowbite-svelte'
+import { TagSolid } from 'flowbite-svelte-icons'
+import highlight from 'highlight.js'
+import { onDestroy } from 'svelte'
+import { page } from '$app/stores'
+
+type MicroCMSImage = { url: string }
+type Blog = {
+	id: string
+	title: string
+	content: string
+	eyecatch?: MicroCMSImage
+}
+
+let loading = true
+let errorMessage: string | null = null
+let data: Blog | null = null
+
+let article = ''
+let description = 'Blog page'
+
+let abortController: AbortController | null = null
+
+async function loadDetail(pageId: string) {
+	loading = true
+	errorMessage = null
+	data = null
+	abortController?.abort()
+	abortController = new AbortController()
+	try {
+		const res = await fetch(
+			`/api/blog/page?pageId=${encodeURIComponent(pageId)}`,
+			{ signal: abortController.signal },
+		)
+		if (!res.ok) {
+			throw new Error(`Failed to load (status ${res.status})`)
+		}
+
+		data = (await res.json()) as Blog
+
+		if (data.content) {
+			const cheeArticle = load(data.content)
+			cheeArticle('pre code').each((_, elm) => {
+				const result = highlight.highlightAuto(cheeArticle(elm).text())
+				cheeArticle(elm).html(result.value)
+				cheeArticle(elm).addClass('hljs')
+			})
+			article = cheeArticle.html()
+
+			const cheeDescription = load(data.content)
+			description = cheeDescription('*').text().substring(0, 50)
+		}
+	} catch (e) {
+		errorMessage = (e as Error).message
+	} finally {
+		loading = false
+	}
+}
+
+const unsubscribe = page.subscribe($page => {
+	const id = $page.url.searchParams.get('pageId')
+	if (id) {
+		loadDetail(id)
+	} else {
+		loading = false
+		errorMessage = 'Missing pageId'
+	}
+})
+onDestroy(() => unsubscribe())
+</script>
+
+<svelte:head>
+	<title>{data?.title ?? 'Blog'} | NaoNao</title>
+	<meta name="description" content={description} />
+</svelte:head>
+
+{#if loading}
+	<section class="px-4 sm:px-auto">
+		<div class="animate-pulse">
+			<div class="h-8 bg-gray-200 dark:bg-gray-700 rounded w-2/3 mb-6"></div>
+			<div class="h-64 bg-gray-200 dark:bg-gray-700 rounded"></div>
+		</div>
+	</section>
+
+{:else if errorMessage}
+	<p class="px-4 text-red-600">{errorMessage}</p>
+
+{:else if data}
+	<article class="prose dark:prose-invert max-w-none px-4 sm:px-auto">
+		<Heading tag="h1" class="mb-4">{data.title}</Heading>
+
+		{#if data.eyecatch}
+			<img src={data.eyecatch.url} alt={data.title} class="rounded-lg mb-6" />
+		{/if}
+
+		<div class="content">
+			{@html article}
+		</div>
+
+		<div class='flex justify-between flex-wrap'>
+			{#if data.category}
+				<Badge border class='ml-auto'>
+					<TagSolid class='mr-1' />
+					{data.category.name}
+				</Badge>
+			{/if}
+		</div>
+
+	</article>
+{/if}
+
+<style lang='scss'>
+	@import 'highlight.js/styles/tokyo-night-dark.min.css';
+
+	.content {
+		font-size: 16px;
+
+		:global(h1) {
+			font-size: 2em;
+			line-height: 2.5em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+			border-bottom-width: 1px;
+
+			&::before {
+				content: "#";
+				margin-right: 0.25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h2) {
+			font-size: 1.875em;
+			line-height: 2.25em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "##";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h3) {
+			font-size: 1.5em;
+			line-height: 2em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "###";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h4) {
+			font-size: 1.25em;
+			line-height: 1.75em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "####";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h5) {
+			font-size: 1.125em;
+			line-height: 1.75em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "#####";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(p) {
+			margin: .5em auto 1em auto;
+			line-height: 1.75em;
+		}
+
+		:global(a) {
+			--tw-text-opacity: 1;
+			color: rgb(106 127 193 / var(--tw-text-opacity));
+
+			&:hover {
+				text-decoration-line: underline;
+			}
+
+			@media (prefers-color-scheme: dark) {
+				--tw-text-opacity: 1;
+				color: rgb(131 157 209 / var(--tw-text-opacity));
+			}
+		}
+
+		:global(blockquote) {
+			padding: 1em 0 1em 1em;
+			margin-top: .25em;
+			border-left-width: 2px;
+			--tw-border-opacity: 1;
+			border-color: rgb(156 182 221 / var(--tw-border-opacity));
+		}
+
+		:global(code) {
+			padding: .25em .5em;
+			border-radius: .375em;
+			--tw-text-opacity: 1;
+			color: rgb(242 247 251 / var(--tw-text-opacity));
+			--tw-bg-opacity: 1;
+			background-color: rgb(38 44 64 / var(--tw-bg-opacity));
+		}
+
+		:global(pre) {
+			width: 100%;
+			margin-top: 1em;
+			margin-bottom: 1em;
+			border-width: 8px;
+			--tw-border-opacity: 1;
+			border-color: rgb(38 44 64 / var(--tw-border-opacity));
+			border-radius: .375em;
+			--tw-bg-opacity: 1;
+			background-color: rgb(38 44 64 / var(--tw-bg-opacity));
+
+			:global(code) {
+				margin: .25em .75em;
+				--tw-text-opacity: 1;
+				color: rgb(242 247 251 / var(--tw-text-opacity));
+				background-color: inherit;
+			}
+		}
+
+		:global(ul) {
+			padding-left: 1.25em;
+			list-style-type: disc;
+		}
+
+		:global(li) {
+			line-height: 1.75em;
+		}
+
+		:global(ol) {
+			padding-left: 1.5em;
+			list-style-type: decimal;
+		}
+	}
+</style>

--- a/src/routes/blog/pages/+page.svelte
+++ b/src/routes/blog/pages/+page.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+import { Button, Heading } from 'flowbite-svelte'
+import { ArrowRightOutline, BookSolid } from 'flowbite-svelte-icons'
+import { onDestroy } from 'svelte'
+import { page } from '$app/stores'
+
+type MicroCMSImage = { url: string }
+type Blog = {
+	id: string
+	title: string
+	content: string
+	eyecatch?: MicroCMSImage
+}
+type BlogResponse = {
+	totalCount: number
+	offset: number
+	limit: number
+	contents: Blog[]
+}
+
+let loading = true
+let errorMessage: string | null = null
+let data: BlogResponse | null = null
+
+let abortController: AbortController | null = null
+
+async function loadList(currentPage: number) {
+	loading = true
+	errorMessage = null
+	data = null
+	abortController?.abort()
+	abortController = new AbortController()
+	try {
+		const res = await fetch(`/api/blog/pages?page=${currentPage}`, {
+			signal: abortController.signal,
+		})
+		if (!res.ok) throw new Error(`Failed to load (status ${res.status})`)
+		data = (await res.json()) as BlogResponse
+	} catch (e) {
+		errorMessage = (e as Error).message
+	} finally {
+		loading = false
+	}
+}
+
+const unsubscribe = page.subscribe($page => {
+	const p = Number($page.url.searchParams.get('page') || '1')
+	loadList(Number.isFinite(p) && p > 0 ? p : 1)
+})
+onDestroy(() => unsubscribe())
+</script>
+
+<svelte:head>
+	<title>Blog | NaoNao</title>
+	<meta name="description" content="NaoNao blog" />
+</svelte:head>
+
+<Heading tag="h2" class="mt-8 mb-12 px-4 sm:px-auto">
+	<BookSolid class="inline-block" size="xl" />
+	Blog
+</Heading>
+
+{#if loading}
+	<!-- Loading placeholder -->
+	<section class="px-4 sm:px-auto">
+		<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+			{#each Array(6) as _, i}
+				<div class="animate-pulse bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 shadow-md overflow-hidden" aria-busy="true" aria-live="polite" aria-label="Loading blog cards">
+					<div class="bg-gray-200 dark:bg-gray-700 aspect-video"></div>
+					<div class="p-4">
+						<div class="h-6 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-4"></div>
+						<div class="h-10 bg-gray-200 dark:bg-gray-700 rounded w-24"></div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	</section>
+{:else if errorMessage}
+	<p class="px-4 text-red-600">{errorMessage}</p>
+{:else if data}
+	<section class="flex flex-wrap gap-4 md:gap-12 px-4 sm:px-auto">
+		{#each data.contents as content (content.id)}
+			<a href="/blog/page?pageId={content.id}"
+				class="bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 rounded-lg border border-gray-200 dark:border-gray-700 divide-gray-200 dark:divide-gray-700 shadow-md w-full sm:w-1/4 md:w-1/4 max-w-sm flex flex-col hover:bg-gray-100 dark:hover:bg-gray-700"
+			>
+				<img src="{content.eyecatch?.url ?? '/images/No_Image.png'}"
+					 alt="{content.eyecatch ? content.title : 'No Image'}"
+					 class="rounded-t-lg object-cover aspect-video" />
+				<div class="h-full p-4 sm:p-6 flex flex-col justify-between">
+					<Heading tag="h3" class="mb-4 text-xl">{content.title}</Heading>
+					<Button class="w-fit mt-auto">
+						Read more
+						<ArrowRightOutline class="w-6 h-6 ms-2 text-white" />
+					</Button>
+				</div>
+			</a>
+		{/each}
+	</section>
+{/if}
+
+<style lang='scss'>
+	@import 'highlight.js/styles/tokyo-night-dark.min.css';
+
+	.content {
+		font-size: 16px;
+
+		:global(h1) {
+			font-size: 2em;
+			line-height: 2.5em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+			border-bottom-width: 1px;
+
+			&::before {
+				content: "#";
+				margin-right: 0.25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h2) {
+			font-size: 1.875em;
+			line-height: 2.25em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "##";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h3) {
+			font-size: 1.5em;
+			line-height: 2em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "###";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h4) {
+			font-size: 1.25em;
+			line-height: 1.75em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "####";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(h5) {
+			font-size: 1.125em;
+			line-height: 1.75em;
+			margin-top: .75em;
+			margin-bottom: .5em;
+
+			&::before {
+				content: "#####";
+				margin-right: .25em;
+				--tw-text-opacity: 1;
+				color: rgb(74 89 137 / var(--tw-text-opacity));
+
+				@media (prefers-color-scheme: dark) {
+					--tw-text-opacity: 1;
+					color: rgb(131 157 209 / var(--tw-text-opacity));
+				}
+			}
+		}
+
+		:global(p) {
+			margin: .5em auto 1em auto;
+			line-height: 1.75em;
+		}
+
+		:global(a) {
+			--tw-text-opacity: 1;
+			color: rgb(106 127 193 / var(--tw-text-opacity));
+
+			&:hover {
+				text-decoration-line: underline;
+			}
+
+			@media (prefers-color-scheme: dark) {
+				--tw-text-opacity: 1;
+				color: rgb(131 157 209 / var(--tw-text-opacity));
+			}
+		}
+
+		:global(blockquote) {
+			padding: 1em 0 1em 1em;
+			margin-top: .25em;
+			border-left-width: 2px;
+			--tw-border-opacity: 1;
+			border-color: rgb(156 182 221 / var(--tw-border-opacity));
+		}
+
+		:global(code) {
+			padding: .25em .5em;
+			border-radius: .375em;
+			--tw-text-opacity: 1;
+			color: rgb(242 247 251 / var(--tw-text-opacity));
+			--tw-bg-opacity: 1;
+			background-color: rgb(38 44 64 / var(--tw-bg-opacity));
+		}
+
+		:global(pre) {
+			width: 100%;
+			margin-top: 1em;
+			margin-bottom: 1em;
+			border-width: 8px;
+			--tw-border-opacity: 1;
+			border-color: rgb(38 44 64 / var(--tw-border-opacity));
+			border-radius: .375em;
+			--tw-bg-opacity: 1;
+			background-color: rgb(38 44 64 / var(--tw-bg-opacity));
+
+			:global(code) {
+				margin: .25em .75em;
+				--tw-text-opacity: 1;
+				color: rgb(242 247 251 / var(--tw-text-opacity));
+				background-color: inherit;
+			}
+		}
+
+		:global(ul) {
+			padding-left: 1.25em;
+			list-style-type: disc;
+		}
+
+		:global(li) {
+			line-height: 1.75em;
+		}
+
+		:global(ol) {
+			padding-left: 1.5em;
+			list-style-type: decimal;
+		}
+	}
+</style>

--- a/src/routes/blog/pages/[contentId]/+page.server.ts
+++ b/src/routes/blog/pages/[contentId]/+page.server.ts
@@ -1,22 +1,10 @@
-import { error } from '@sveltejs/kit'
-import { getBlogPageDetail } from '$lib/microCMS'
+import { redirect } from '@sveltejs/kit'
 // @ts-ignore
 import type { PageServerLoad } from './$types'
 
-export const load: PageServerLoad = async ({
-	params,
-}: {
-	params: { contentId: string }
-}) => {
-	try {
-		return await getBlogPageDetail(params.contentId)
-	} catch (e: unknown) {
-		let status = 500
-		if ((e as Error).message === 'Not found') {
-			status = 404
-		}
-		error(status)
-	}
+export const load: PageServerLoad = async ({ params }: { params: { contentId: string } }) => {
+	const id = params.contentId
+	throw redirect(308, `/blog/page?pageId=${encodeURIComponent(id)}`)
 }
 
 export const prerender = true


### PR DESCRIPTION
## :memo: Summary
This pull request adds a new blog section to the site. It creates API endpoints for fetching blog lists and individual blog pages, rewrites several route handlers to redirect to the new pages, updates the header navigation link, and implements UI components to display the blog list and blog details.

## 📌 Change Point
* Add API routes:
  + /api/blog/page – returns a single blog post by pageId.
  + /api/blog/pages – returns a paginated list of blog posts.
* Create new page routes:
    + /blog/page – shows a single post, fetching data via the API.
    + /blog/pages – shows a paginated list of posts.
    + /blog/pages/[contentId] – redirects to the new /blog/page URL.
* Update Header.svelte navigation to point to /blog/pages.
* Modify +page.server.ts files to use redirects instead of loading data directly.
* Add Svelte components for rendering the blog list and post content, including styling and loading placeholders.
